### PR TITLE
Fix for newer version of Guzzle

### DIFF
--- a/src/Jcf/Geocode/Geocode.php
+++ b/src/Jcf/Geocode/Geocode.php
@@ -18,7 +18,7 @@ class Geocode
             throw new Exceptions\EmptyArgumentsException('Empty arguments.');
         }
 		$client = new \GuzzleHttp\Client();
-		$response = json_decode($client->request('GET', 'http://maps.googleapis.com/maps/api/geocode/json', [
+		$response = json_decode($client->get('http://maps.googleapis.com/maps/api/geocode/json', [
 		    'query' => ['address' => $address]
 		])->getBody());
 


### PR DESCRIPTION
The updated version of Guzzle no longer uses the 'request' method on the object. 
