### PR TITLE
Added $response->postalCode()

### DIFF
--- a/src/Jcf/Geocode/Response.php
+++ b/src/Jcf/Geocode/Response.php
@@ -32,4 +32,15 @@ class Response
 	{
 		return $this->response->geometry->location_type;
 	}
+	
+	public function postalCode()
+    	{
+		foreach ($this->response->address_components as $component) {
+		    if (isset($component->types) && in_array('postal_code', $component->types)) {
+			return $component->long_name;
+		    }
+		}
+
+        	return false;
+    	}
 }


### PR DESCRIPTION
Depending on (in my case) which country I was querying coordinates from, postal code was either 8th (US) or 6th (NL) entry in address_components. Fixed this with a loop in a new method.