### PR TITLE
Ability to use custom params when doing an address lookup

### DIFF
--- a/src/Jcf/Geocode/Geocode.php
+++ b/src/Jcf/Geocode/Geocode.php
@@ -20,14 +20,14 @@ class Geocode
         return new static();
     }
 
-    public function address($address)
+    public function address($address, $params = [])
     {
 
         if (empty($address)) {
             throw new Exceptions\EmptyArgumentsException('Empty arguments.');
         }
         $client = new \GuzzleHttp\Client();
-        $params = ['address' => $address];
+        $params = array_merge($params, ['address' => $address]);
         if (!empty($this->apiKey)) {
             $params['key'] = $this->apiKey;
         }


### PR DESCRIPTION
By allowing custom params we can limit the results to a specific country.

e.g. Geocode::make()->address($searched_term, ['components' => 'country:GB']);